### PR TITLE
fix: missing whitespace

### DIFF
--- a/source/Components/CommentForm.mint
+++ b/source/Components/CommentForm.mint
@@ -60,13 +60,13 @@ component CommentForm {
             "Sign in"
           </a>
 
-          <span>"or"</span>
+          <span>" or "</span>
 
           <a href="/sign-up">
             "sign up"
           </a>
 
-          <span>"to add comments on this article."</span>
+          <span>" to add comments on this article."</span>
         </div>
     }
   }


### PR DESCRIPTION
As seen in the screenshot there is no whitespace between the link, `or` and before `to` 🙂 

<img width="459" alt="Bildschirmfoto 2021-04-16 um 15 55 31" src="https://user-images.githubusercontent.com/1759475/115034791-2e2ab580-9ecc-11eb-8682-0ae5349f416a.png">
