### PR TITLE
Fix compiler errors in latest mint

### DIFF
--- a/source/Actions.mint
+++ b/source/Actions.mint
@@ -50,7 +50,7 @@ store Actions {
         Api.send(Article.fromResponse, request)
 
       case (status) {
-        Api.Status::Ok article => Stores.Articles.replaceArticle(article)
+        Api.Status::Ok(article) => Stores.Articles.replaceArticle(article)
 
         => Promise.never()
       }

--- a/source/Api.mint
+++ b/source/Api.mint
@@ -21,7 +21,7 @@ module Api {
 
   fun withDefault (a : a, status : Api.Status(a)) : a {
     case (status) {
-      Api.Status::Ok value => value
+      Api.Status::Ok(value) => value
       => a
     }
   }
@@ -43,7 +43,7 @@ module Api {
 
   fun errorsOf (key : String, status : Api.Status(a)) : Array(String) {
     case (status) {
-      Api.Status::Error errors =>
+      Api.Status::Error(errors) =>
         errors
         |> Map.get(key)
         |> Maybe.withDefault([])
@@ -77,7 +77,7 @@ module Api {
       /* We try to get a token from session storage. */
       request =
         case (Application.user) {
-          UserStatus::LoggedIn user =>
+          UserStatus::LoggedIn(user) =>
             Http.header(
               "Authorization",
               "Token " + user.token,

--- a/source/Components/Article.Comments.mint
+++ b/source/Components/Article.Comments.mint
@@ -14,7 +14,7 @@ component Article.Comments {
   } where {
     comments =
       case (status) {
-        Api.Status::Ok comments => comments
+        Api.Status::Ok(comments) => comments
         => []
       }
   }

--- a/source/Components/CommentForm.mint
+++ b/source/Components/CommentForm.mint
@@ -32,7 +32,7 @@ component CommentForm {
 
   fun render : Html {
     case (user) {
-      UserStatus::LoggedIn user =>
+      UserStatus::LoggedIn(user) =>
         <div::form>
           <Form.Field>
             <Textarea

--- a/source/Components/PopularTags.mint
+++ b/source/Components/PopularTags.mint
@@ -51,7 +51,7 @@ component PopularTags {
   } where {
     tags =
       case (status) {
-        Api.Status::Ok tags => tags
+        Api.Status::Ok(tags) => tags
         => []
       }
   }

--- a/source/Forms/Article.mint
+++ b/source/Forms/Article.mint
@@ -73,7 +73,7 @@ store Forms.Article {
         |> Api.send(Article.fromResponse)
 
       case (newStatus) {
-        Api.Status::Ok article => Window.navigate("/article/" + article.slug)
+        Api.Status::Ok(article) => Window.navigate("/article/" + article.slug)
         => next { status = newStatus }
       }
     }

--- a/source/Forms/Settings.mint
+++ b/source/Forms/Settings.mint
@@ -54,7 +54,7 @@ store Forms.Settings {
         |> Api.send(User.fromResponse)
 
       case (newStatus) {
-        Api.Status::Ok user =>
+        Api.Status::Ok(user) =>
           parallel {
             Application.setUser(user)
             Window.navigate("/users/" + username)

--- a/source/Forms/SignIn.mint
+++ b/source/Forms/SignIn.mint
@@ -40,7 +40,7 @@ store Forms.SignIn {
         |> Api.send(User.fromResponse)
 
       case (newStatus) {
-        Api.Status::Ok user => Application.login(user)
+        Api.Status::Ok(user) => Application.login(user)
         => next { status = newStatus }
       }
     }

--- a/source/Forms/SignUp.mint
+++ b/source/Forms/SignUp.mint
@@ -37,7 +37,7 @@ store Forms.SignUp {
         |> Api.send(User.fromResponse)
 
       case (newStatus) {
-        Api.Status::Ok user => Application.login(user)
+        Api.Status::Ok(user) => Application.login(user)
         => next { status = newStatus }
       }
     }

--- a/source/Layout/Header.mint
+++ b/source/Layout/Header.mint
@@ -146,7 +146,7 @@ component Header {
           </a>
         </>
 
-      UserStatus::LoggedIn user =>
+      UserStatus::LoggedIn(user) =>
         <>
           <a::link href="/new">
             <svg

--- a/source/Pages/Article.mint
+++ b/source/Pages/Article.mint
@@ -83,7 +83,7 @@ component Pages.Article {
 
   get isMine : Bool {
     case (user) {
-      UserStatus::LoggedIn user => user.username == article.author.username
+      UserStatus::LoggedIn(user) => user.username == article.author.username
       => false
     }
   }

--- a/source/Pages/Profile.mint
+++ b/source/Pages/Profile.mint
@@ -94,7 +94,7 @@ component Profile {
     case (user) {
       UserStatus::LoggedOut => Html.empty()
 
-      UserStatus::LoggedIn user =>
+      UserStatus::LoggedIn(user) =>
         if (user.username != profile.username) {
           <div::button>
             <Button
@@ -120,7 +120,7 @@ component Profile {
         toggleUserFollow(profile)
 
       case (newStatus) {
-        Api.Status::Ok profile => Stores.Profile.setProfile(profile)
+        Api.Status::Ok(profile) => Stores.Profile.setProfile(profile)
         => Promise.never()
       }
 

--- a/source/Routes.mint
+++ b/source/Routes.mint
@@ -84,7 +84,7 @@ routes {
       Application.initialize()
 
       case (Application.user) {
-        UserStatus::LoggedIn user =>
+        UserStatus::LoggedIn(user) =>
           sequence {
             Forms.Settings.set(user)
             Application.setPage(Page::Settings)
@@ -100,7 +100,7 @@ routes {
       Application.initialize()
 
       case (Application.user) {
-        UserStatus::LoggedIn user => Window.navigate("/")
+        UserStatus::LoggedIn(user) => Window.navigate("/")
 
         UserStatus::LoggedOut =>
           parallel {
@@ -117,7 +117,7 @@ routes {
 
       case (Application.user) {
         UserStatus::LoggedOut => Application.setPage(Page::SignUp)
-        UserStatus::LoggedIn user => Window.navigate("/")
+        UserStatus::LoggedIn(user) => Window.navigate("/")
       }
     }
   }
@@ -128,7 +128,7 @@ routes {
       Forms.Article.reset()
 
       case (Application.user) {
-        UserStatus::LoggedIn user => Application.setPage(Page::Editor)
+        UserStatus::LoggedIn(user) => Application.setPage(Page::Editor)
         UserStatus::LoggedOut => Window.navigate("/")
       }
     }
@@ -139,7 +139,7 @@ routes {
       Application.initialize()
 
       case (Application.user) {
-        UserStatus::LoggedIn user => Application.logout()
+        UserStatus::LoggedIn(user) => Application.logout()
         UserStatus::LoggedOut => Window.navigate("/")
       }
     }
@@ -152,7 +152,7 @@ routes {
       sequence {
         article =
           case (Stores.Articles.status) {
-            Api.Status::Ok data =>
+            Api.Status::Ok(data) =>
               data.articles
               |> Array.find(
                 (article : Article) : Bool { article.slug == slug })
@@ -192,7 +192,7 @@ routes {
       }
 
       case (Stores.Article.status) {
-        Api.Status::Ok article =>
+        Api.Status::Ok(article) =>
           parallel {
             Forms.Article.set(article)
             Application.setPage(Page::Editor)

--- a/source/Stores/Articles.mint
+++ b/source/Stores/Articles.mint
@@ -33,7 +33,7 @@ store Stores.Articles {
   } where {
     nextStatus =
       case (status) {
-        Api.Status::Ok data =>
+        Api.Status::Ok(data) =>
           try {
             articles =
               Array.map(


### PR DESCRIPTION
Running `mintlang/mint:latest` had syntax errors. I'm sure you already know this, but this breaks on mint 0.12.0. 